### PR TITLE
Toon Link Bomb Adjustments

### DIFF
--- a/romfs/fighter/toonlink/param/vl.prcxml
+++ b/romfs/fighter/toonlink/param/vl.prcxml
@@ -14,4 +14,14 @@
     <hash40 index="2">dummy</hash40>
     <hash40 index="3">dummy</hash40>
   </list>
+  <list hash="param_toonlinkbomb">
+    <struct index="0">
+      <float hash="toonlinkbomb_throw_speed_mul">0.9</float>
+      <float hash="toonlinkbomb_scale_mul">1.25</float>
+      <float hash="toonlinkbomb_bomb_speed">1.5</float>
+    </struct>
+    <hash40 index="1">dummy</hash40>
+    <hash40 index="2">dummy</hash40>
+    <hash40 index="3">dummy</hash40>
+  </list>
 </struct>


### PR DESCRIPTION
Bomb size increased 1.0 -> 1.25
Bomb throw speed reduced 1.0 -> 0.9
Velocity bomb needs to explode on the ground increased 0.9 -> 1.5