### PR TITLE
Removal of universal airdodge FaF nerf

### DIFF
--- a/romfs/fighter/common/param/fighter_param_motion.prcxml
+++ b/romfs/fighter/common/param/fighter_param_motion.prcxml
@@ -2,25 +2,21 @@
 <struct>
   <list hash="fighter_param_motion_table">
     <struct index="0">
-      <float hash="escape_air_cancel_frame">65</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="1">
-      <float hash="escape_air_cancel_frame">59</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="2">
-      <float hash="escape_air_cancel_frame">65</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="3">
-      <float hash="escape_air_cancel_frame">67</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -36,13 +32,11 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="6">
-      <float hash="escape_air_cancel_frame">50</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="7">
-      <float hash="escape_air_cancel_frame">65</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -58,7 +52,6 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="10">
-      <float hash="escape_air_cancel_frame">53</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -69,7 +62,6 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="12">
-      <float hash="escape_air_cancel_frame">60</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -90,19 +82,16 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="16">
-      <float hash="escape_air_cancel_frame">65</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="17">
-      <float hash="escape_air_cancel_frame">60</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="18">
-      <float hash="escape_air_cancel_frame">65</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -113,7 +102,6 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="20">
-      <float hash="escape_air_cancel_frame">54</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -124,19 +112,16 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="22">
-      <float hash="escape_air_cancel_frame">54</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="23">
-      <float hash="escape_air_cancel_frame">57</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="24">
-      <float hash="escape_air_cancel_frame">62</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -152,19 +137,16 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="27">
-      <float hash="escape_air_cancel_frame">65</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="28">
-      <float hash="escape_air_cancel_frame">65</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="29">
-      <float hash="escape_air_cancel_frame">50</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -176,7 +158,6 @@
     </struct>
     <struct index="31">
       <float hash="escape_air_hit_xlu_frame">3</float>
-      <float hash="escape_air_cancel_frame">50</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -188,7 +169,6 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="33">
-      <float hash="escape_air_cancel_frame">61</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -199,13 +179,11 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="35">
-      <float hash="escape_air_cancel_frame">54</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="36">
-      <float hash="escape_air_cancel_frame">62</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -231,7 +209,6 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="41">
-      <float hash="escape_air_cancel_frame">60</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -248,7 +225,6 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="44">
-      <float hash="escape_air_cancel_frame">55</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -274,13 +250,11 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="49">
-      <float hash="escape_air_cancel_frame">64</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="50">
-      <float hash="escape_air_cancel_frame">52</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -291,13 +265,11 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="52">
-      <float hash="escape_air_cancel_frame">65</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="53">
-      <float hash="escape_air_cancel_frame">60</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -308,7 +280,6 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="55">
-      <float hash="escape_air_cancel_frame">50</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -324,13 +295,11 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="58">
-      <float hash="escape_air_cancel_frame">60</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="59">
-      <float hash="escape_air_cancel_frame">60</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -341,7 +310,6 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="61">
-      <float hash="escape_air_cancel_frame">62</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -352,13 +320,11 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="63">
-      <float hash="escape_air_cancel_frame">60</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="64">
-      <float hash="escape_air_cancel_frame">57</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -369,7 +335,6 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="66">
-      <float hash="escape_air_cancel_frame">55</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -380,25 +345,21 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="68">
-      <float hash="escape_air_cancel_frame">60</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="69">
-      <float hash="escape_air_cancel_frame">65</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="70">
-      <float hash="escape_air_cancel_frame">60</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="71">
-      <float hash="escape_air_cancel_frame">62</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -418,67 +379,56 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="74">
-      <float hash="escape_air_cancel_frame">65</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="75">
-      <float hash="escape_air_cancel_frame">60</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="76">
-      <float hash="escape_air_cancel_frame">60</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="77">
-      <float hash="escape_air_cancel_frame">60</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="78">
-      <float hash="escape_air_cancel_frame">60</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="79">
-      <float hash="escape_air_cancel_frame">60</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="80">
-      <float hash="escape_air_cancel_frame">51</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="81">
-      <float hash="escape_air_cancel_frame">65</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="82">
-      <float hash="escape_air_cancel_frame">65</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="83">
-      <float hash="escape_air_cancel_frame">67</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="84">
-      <float hash="escape_air_cancel_frame">60</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -494,7 +444,6 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="87">
-      <float hash="escape_air_cancel_frame">65</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>
@@ -505,7 +454,6 @@
       <float hash="landing_frame_escape_air_slide">12</float>
     </struct>
     <struct index="89">
-      <float hash="escape_air_cancel_frame">60</float>
       <int hash="escape_air_slide_back_end_frame">-1</int>
       <float hash="landing_frame_escape_air_slide_max">12</float>
       <float hash="landing_frame_escape_air_slide">12</float>


### PR DESCRIPTION
This was added incredibly early into Ultimate S's life, and frankly, it doesnt need to be here anymore.
All airdodge FaFs have been reverted to vanilla