### PR TITLE
Yoshi DJC

### DIFF
--- a/src/common/movement.rs
+++ b/src/common/movement.rs
@@ -56,7 +56,7 @@ pub fn djc(fighter : &mut L2CFighterCommon) {
 		let ENTRY_ID = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
 		let fighter_kind = smash::app::utility::get_kind(boma);
 		let status_kind = smash::app::lua_bind::StatusModule::status_kind(boma);
-		if [*FIGHTER_KIND_NESS, *FIGHTER_KIND_LUCAS, *FIGHTER_KIND_YOSHI, *FIGHTER_KIND_MEWTWO].contains(&fighter_kind) {
+		if [*FIGHTER_KIND_NESS, *FIGHTER_KIND_LUCAS, /**FIGHTER_KIND_YOSHI,*/ *FIGHTER_KIND_MEWTWO].contains(&fighter_kind) {
 			if [*FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION_2ND, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL].contains(&KineticModule::get_kinetic_type(boma)) {
 				if ControlModule::check_button_off(boma, *CONTROL_PAD_BUTTON_JUMP) && [*FIGHTER_TRAIL_STATUS_KIND_ATTACK_AIR_N, *FIGHTER_STATUS_KIND_ATTACK_AIR, *FIGHTER_STATUS_KIND_AIR_LASSO].contains(&status_kind) {
 					KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_MOTION_FALL);


### PR DESCRIPTION
Due to issues with his DJC, Yoshi will not have it for now. 

The main issue is that a held jump input is supposed to override the DJC and since that doesn't work for Yoshi, it's got to go for now.