### PR TITLE
huge param update

### DIFF
--- a/romfs/fighter/common/param/fighter_param.prcxml
+++ b/romfs/fighter/common/param/fighter_param.prcxml
@@ -641,7 +641,6 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">8</float>
       <float hash="landing_attack_air_frame_hi">9</float>
-      
       <float hash="scale">1.05</float>
       <float hash="shield_radius">10.5</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>

--- a/romfs/fighter/common/param/fighter_param.prcxml
+++ b/romfs/fighter/common/param/fighter_param.prcxml
@@ -431,12 +431,12 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
     <!--FOX-->
     <struct index="6">
       <float hash="dash_speed">2.37</float>
-      <float hash="run_speed_max">2.2</float>
+      <float hash="run_speed_max">2.0</float>
       <float hash="jump_speed_x">0.85</float>
       <float hash="jump_speed_x_mul">1.15</float>
       <float hash="jump_speed_x_max">2.5</float>
-      <float hash="air_accel_y">0.2</float>
-      <float hash="air_speed_y_stable">2.2</float>
+      <float hash="air_accel_y">0.175</float>
+      <float hash="air_speed_y_stable">2.3</float>
       <float hash="dive_speed_y">4.025</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_lw">12</float>
@@ -501,7 +501,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
     </struct>
     <!--JIGGLYPUFF-->
     <struct index="11">
-      <float hash="walk_speed_max">1.0</float>
+      <float hash="walk_speed_max">1.2</float>
       <float hash="dash_speed">1.76</float>
       <float hash="run_speed_max">1.35</float>
       <float hash="weight">75</float>

--- a/romfs/fighter/common/param/fighter_param.prcxml
+++ b/romfs/fighter/common/param/fighter_param.prcxml
@@ -71,7 +71,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_hi">6</float>
       <float hash="landing_attack_air_frame_lw">15</float>
       <float hash="landing_frame_light">1</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="scale">1</float>
       <float hash="shield_radius">9.7</float>
       <float hash="shield_break_y">44.1</float>
@@ -366,7 +366,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
     <!--MARIO-->
     <struct index="0">
       <float hash="jump_speed_x_mul">1.2</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -399,11 +399,12 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_hi">7</float>
       <float hash="landing_attack_air_frame_f">13</float>
       <float hash="landing_attack_air_frame_n">9</float>
+      <float hash="landing_frame">3</float>
     </struct>
     <!--SAMUS-->
     <struct index="3">
       <float hash="jump_speed_x_mul">0.9</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -414,7 +415,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="air_speed_y_stable">1.5</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">7</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -423,23 +424,23 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="run_speed_max">1.775</float>
       <float hash="jump_speed_x_mul">1</float>
       <float hash="air_speed_x_stable">0.95</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
     <!--FOX-->
     <struct index="6">
       <float hash="dash_speed">2.37</float>
-      <float hash="run_speed_max">2</float>
+      <float hash="run_speed_max">2.2</float>
       <float hash="jump_speed_x">0.85</float>
       <float hash="jump_speed_x_mul">1.15</float>
       <float hash="jump_speed_x_max">2.5</float>
-      <float hash="air_accel_y">0.175</float>
-      <float hash="air_speed_y_stable">2.3</float>
+      <float hash="air_accel_y">0.2</float>
+      <float hash="air_speed_y_stable">2.2</float>
       <float hash="dive_speed_y">4.025</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_lw">12</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -458,7 +459,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_b">6</float>
       <float hash="landing_attack_air_frame_hi">8</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -468,7 +469,6 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="jump_speed_x_mul">1</float>
       <float hash="air_speed_x_stable">1.08</float>
       <float hash="dive_speed_y">2.508</float>
-      <float hash="landing_frame">4</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
       <bool hash="wall_jump_type">true</bool>
@@ -480,7 +480,6 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="dive_speed_y">2.47</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">8</float>
-      <float hash="landing_frame">4</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
       <bool hash="wall_jump_type">true</bool>
@@ -497,18 +496,16 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_f">14</float>
       <float hash="landing_attack_air_frame_b">8</float>
       <float hash="landing_attack_air_frame_hi">6</float>
-      <float hash="landing_frame">4</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
     <!--JIGGLYPUFF-->
     <struct index="11">
-      <float hash="walk_speed_max">1.2</float>
+      <float hash="walk_speed_max">1.0</float>
       <float hash="dash_speed">1.76</float>
       <float hash="run_speed_max">1.35</float>
       <float hash="weight">75</float>
       <float hash="landing_attack_air_frame_lw">9</float>
-      <float hash="landing_frame">4</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -516,24 +513,24 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
     <struct index="12">
       <float hash="air_accel_x_mul">0.06</float>
       <float hash="landing_attack_air_frame_n">7</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
     <!--BOWSER-->
     <struct index="13">
+      <float hash="landing_attack_air_frame_n">12</float>
       <float hash="landing_attack_air_frame_lw">18</float>
       <float hash="landing_frame">4</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
-      <float hash="landing_attack_air_frame_n">12</float>
     </struct>
     <!--POPO-->
     <struct index="14">
       <float hash="ground_brake">0.0525</float>
       <float hash="air_speed_x_stable">0.88</float>
       <float hash="weight">86</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="scale">1.15</float>
       <float hash="shield_radius">11.6</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
@@ -544,7 +541,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="ground_brake">0.0602</float>
       <float hash="air_speed_x_stable">0.9</float>
       <float hash="weight">86</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="scale">1.15</float>
       <float hash="shield_radius">11.6</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
@@ -557,7 +554,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="weight">76</float>
       <float hash="landing_attack_air_frame_b">7</float>
       <float hash="landing_attack_air_frame_lw">6</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -566,7 +563,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="jump_speed_x_mul">0.8</float>
       <float hash="air_accel_x_mul">0.09</float>
       <float hash="landing_attack_air_frame_f">11</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -585,7 +582,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_n">6</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">13</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="scale">1.15</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
@@ -595,7 +592,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="jump_speed_x_mul">1.475</float>
       <float hash="air_speed_x_stable">1.1</float>
       <float hash="weight">75</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -614,7 +611,6 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="dive_speed_y">2.92</float>
       <float hash="landing_attack_air_frame_n">6</float>
       <float hash="landing_attack_air_frame_b">11</float>
-      <float hash="landing_frame">4</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -630,7 +626,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="weight">85</float>
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_f">12</float>
-      <float hash="landing_frame">4</float>
+      <float hash="landing_frame">3</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
       <float hash="combo_attack_12_end">0</float>
@@ -645,7 +641,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">8</float>
       <float hash="landing_attack_air_frame_hi">9</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="scale">1.05</float>
       <float hash="shield_radius">10.5</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
@@ -674,6 +670,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_f">7</float>
       <float hash="landing_attack_air_frame_b">8</float>
       <float hash="landing_attack_air_frame_hi">9</float>
+      <float hash="landing_frame">3</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -697,7 +694,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_f">12</float>
       <float hash="landing_attack_air_frame_b">15</float>
       <float hash="landing_attack_air_frame_lw">10</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="scale">0.89</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
@@ -713,7 +710,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="weight">78</float>
       <float hash="landing_attack_air_frame_f">8</float>
       <float hash="landing_attack_air_frame_lw">18</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -737,7 +734,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="weight">85</float>
       <float hash="landing_attack_air_frame_n">10</float>
       <float hash="landing_attack_air_frame_b">8</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
       <float hash="combo_attack_12_end">0</float>
@@ -749,13 +746,13 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
     <struct index="30">
       <float hash="air_accel_x_mul">0.11</float>
       <float hash="weight">104</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
     <!--SNAKE-->
     <struct index="31">
-      <float hash="landing_frame">4</float>
+      
       <float hash="scale">1.075</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
@@ -766,7 +763,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="run_speed_max">1.6</float>
       <float hash="landing_attack_air_frame_n">10</float>
       <float hash="landing_attack_air_frame_f">11</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -777,7 +774,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="air_speed_x_stable">1.11</float>
       <float hash="landing_attack_air_frame_f">8</float>
       <float hash="landing_attack_air_frame_hi">8</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -786,7 +783,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_f">11</float>
       <float hash="landing_attack_air_frame_hi">16</float>
       <float hash="landing_attack_air_frame_lw">16</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -801,7 +798,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
     <!--DIDDY KONG-->
     <struct index="36">
       <float hash="jump_speed_x_mul">1.075</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
       <float hash="clip_sphere_offset_x">0</float>
@@ -820,7 +817,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="air_speed_y_stable">1.9</float>
       <float hash="dive_speed_y">3.04</float>
       <float hash="landing_attack_air_frame_f">9</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -841,7 +838,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_b">9</float>
       <float hash="landing_attack_air_frame_hi">8</float>
       <float hash="landing_attack_air_frame_lw">14</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
       <int hash="attack_combo_max">2</int>
@@ -865,7 +862,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
     </struct>
     <!--OLIMAR-->
     <struct index="40">
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -873,7 +870,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
     <struct index="41">
       <float hash="air_speed_x_stable">1.155</float>
       <float hash="mini_jump_y">16</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -883,7 +880,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="weight">110</float>
       <float hash="landing_attack_air_frame_n">10</float>
       <float hash="landing_attack_air_frame_f">7</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -894,7 +891,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="jump_speed_x_mul">1.5</float>
       <float hash="dive_speed_y">2.622</float>
       <float hash="weight">87</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -903,14 +900,14 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="jump_speed_x_mul">1</float>
       <float hash="weight">87</float>
       <float hash="landing_attack_air_frame_n">11</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="scale">1.14</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
     <!--VILLAGER-->
     <struct index="45">
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -918,7 +915,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
     <struct index="46">
       <float hash="landing_attack_air_frame_n">11</float>
       <float hash="landing_attack_air_frame_b">10</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -927,7 +924,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="jump_speed_x_mul">1.2</float>
       <float hash="air_speed_y_stable">1.75</float>
       <float hash="dive_speed_y">2.72</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -936,7 +933,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="dash_speed">1.8</float>
       <float hash="run_speed_max">1.7</float>
       <float hash="jump_speed_x_mul">1.1</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -949,7 +946,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_n">5</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_b">9</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -960,7 +957,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="mini_jump_y">15</float>
       <float hash="weight">84</float>
       <float hash="landing_attack_air_frame_n">9</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -970,7 +967,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="jump_speed_x_mul">0.9</float>
       <float hash="landing_attack_air_frame_n">12</float>
       <float hash="landing_attack_air_frame_b">10</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -982,14 +979,14 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="jump_speed_x_mul">1</float>
       <float hash="landing_attack_air_frame_hi">8</float>
       <float hash="landing_attack_air_frame_lw">9</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
     <!--ROBIN-->
     <struct index="53">
       <float hash="run_speed_max">1.4</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -997,7 +994,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
     <struct index="54">
       <float hash="jump_speed_x_mul">1.2</float>
       <float hash="landing_attack_air_frame_n">10</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1008,7 +1005,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="run_speed_max">1.7</float>
       <float hash="jump_speed_x_mul">1.1</float>
       <float hash="landing_attack_air_frame_f">11</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
       <float hash="clip_sphere_offset_x">0.5</float>
@@ -1023,7 +1020,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="dive_speed_y">2.72</float>
       <float hash="landing_attack_air_frame_f">7</float>
       <float hash="landing_attack_air_frame_hi">10</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1031,7 +1028,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
     <struct index="57">
       <float hash="air_speed_x_stable">1.1</float>
       <float hash="landing_attack_air_frame_n">6</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1048,7 +1045,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="damage_fly_top_air_accel_y">0.076608</float>
       <float hash="landing_attack_air_frame_b">10</float>
       <float hash="landing_attack_air_frame_lw">21</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1064,7 +1061,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">12</float>
       <float hash="landing_attack_air_frame_hi">11</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="scale">1.0395</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
@@ -1075,7 +1072,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
     <!--BAYONETTA-->
     <struct index="60">
       <float hash="jump_speed_x_mul">1.5</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1090,7 +1087,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_n">5</float>
       <float hash="landing_attack_air_frame_f">14</float>
       <float hash="landing_attack_air_frame_b">7</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1101,7 +1098,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="weight">113</float>
       <float hash="landing_attack_air_frame_f">13</float>
       <float hash="landing_attack_air_frame_hi">11</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1109,7 +1106,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
     <struct index="63">
       <float hash="jump_speed_x_mul">1.075</float>
       <float hash="air_speed_y_stable">1.6</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="shield_radius">13</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
@@ -1135,7 +1132,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_b">9</float>
       <float hash="landing_attack_air_frame_hi">6</float>
       <float hash="landing_attack_air_frame_lw">6</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="scale">1.05</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
@@ -1147,7 +1144,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="air_speed_x_stable">0.9875</float>
       <float hash="landing_attack_air_frame_f">11</float>
       <float hash="landing_attack_air_frame_b">8</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1160,7 +1157,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_b">12</float>
       <float hash="landing_attack_air_frame_lw">12</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1174,7 +1171,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="air_speed_x_stable">1.175</float>
       <float hash="air_speed_y_stable">1.93</float>
       <float hash="dive_speed_y">3.088</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1182,7 +1179,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
     <struct index="69">
       <hash40 hash="clip_sphere_node">bust</hash40>
       <float hash="jump_speed_x_mul">1</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
       <float hash="landing_attack_air_frame_f">10</float>
@@ -1195,14 +1192,14 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_n">12</float>
       <float hash="landing_attack_air_frame_b">11</float>
       <float hash="landing_attack_air_frame_hi">10</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
     <!--TERRY-->
     <struct index="71">
       <hash40 hash="clip_sphere_node">bust</hash40>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
       <float hash="clip_sphere_offset_x">2</float>
@@ -1221,7 +1218,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_b">11</float>
       <float hash="landing_attack_air_frame_hi">11</float>
       <float hash="landing_attack_air_frame_lw">20</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1234,7 +1231,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="weight">85</float>
       <float hash="landing_attack_air_frame_n">10</float>
       <float hash="landing_attack_air_frame_f">10</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1243,7 +1240,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="dash_speed">1.5</float>
       <float hash="jump_speed_x_mul">1.05</float>
       <float hash="air_speed_x_stable">0.91</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1291,7 +1288,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="weight">97</float>
       <float hash="landing_attack_air_frame_n">10</float>
       <float hash="landing_attack_air_frame_f">15</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1305,7 +1302,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="jump_aerial_y">27.5</float>
       <float hash="weight">85</float>
       <float hash="landing_attack_air_frame_lw">8</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1315,7 +1312,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="air_speed_x_stable">1.1</float>
       <float hash="landing_attack_air_frame_n">6</float>
       <float hash="landing_attack_air_frame_hi">15</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
       <float hash="clip_sphere_offset_x">0</float>
@@ -1332,7 +1329,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">8</float>
       <float hash="landing_attack_air_frame_lw">26</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1358,7 +1355,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_f">15</float>
       <float hash="landing_attack_air_frame_lw">15</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1377,7 +1374,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_n">6</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_hi">12</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
       <float hash="combo_attack_12_end">0</float>
@@ -1396,7 +1393,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="weight">83</float>
       <float hash="landing_attack_air_frame_n">11</float>
       <float hash="landing_attack_air_frame_b">9</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1415,7 +1412,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="weight">85</float>
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_f">12</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1452,6 +1449,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_hi">8</float>
+      <float hash="landing_frame">3</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1461,7 +1459,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="run_speed_max">1.68</float>
       <float hash="air_speed_x_stable">1.1</float>
       <float hash="landing_attack_air_frame_n">6</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
@@ -1474,7 +1472,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="landing_attack_air_frame_f">13</float>
       <float hash="landing_attack_air_frame_b">13</float>
       <float hash="landing_attack_air_frame_hi">6</float>
-      <float hash="landing_frame">4</float>
+      
       <float hash="shield_radius">13</float>
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
@@ -1487,19 +1485,19 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
     </struct>
     <!--MII BRAWLER (FIGHTING MII TEAM)-->
     <struct index="91">
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
     <!--MII SWORDFIGHTER (FIGHTING MII TEAM)-->
     <struct index="92">
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>
     <!--MII GUNNER (FIGHTING MII TEAM)-->
     <struct index="93">
-      <float hash="landing_frame">4</float>
+      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>

--- a/romfs/fighter/common/param/fighter_param.prcxml
+++ b/romfs/fighter/common/param/fighter_param.prcxml
@@ -431,7 +431,7 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
     <!--FOX-->
     <struct index="6">
       <float hash="dash_speed">2.37</float>
-      <float hash="run_speed_max">2.0</float>
+      <float hash="run_speed_max">2</float>
       <float hash="jump_speed_x">0.85</float>
       <float hash="jump_speed_x_mul">1.15</float>
       <float hash="jump_speed_x_max">2.5</float>
@@ -440,7 +440,6 @@ When adding a new change, make sure it is in ORDER! Here is an example of the or
       <float hash="dive_speed_y">4.025</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_lw">12</float>
-      
       <float hash="tread_jump_speed_y_mul">1.0</float>
       <float hash="tread_mini_jump_speed_y_mul">0.475</float>
     </struct>


### PR DESCRIPTION
All characters reverted to vanilla hard landing lag except for:

bowser/ddd/krool (kept at 4, vanilla is 5)
dpit/link (reduced to 3, vanilla is 4)

Jigglypuff walk decreased (was 1.2 while her max run speed was 1.35, certainly one of the choices of all time): 1.2 > 1.0


