### PR TITLE
Knockdown throws

### DIFF
--- a/src/common/hitstun.rs
+++ b/src/common/hitstun.rs
@@ -71,7 +71,7 @@ pub unsafe fn status_pre_DamageAir(fighter: &mut L2CFighterCommon) -> L2CValue {
         return 1.into();
     }
 
-    call_original!(fighter)
+    return original!()(fighter);
 }
 
 

--- a/src/common/wavedash.rs
+++ b/src/common/wavedash.rs
@@ -193,19 +193,7 @@ pub unsafe fn change_status_request_hook(boma: &mut smash::app::BattleObjectModu
 			}
 		} else if next_status == *FIGHTER_STATUS_KIND_TURN && curr_status == *FIGHTER_STATUS_KIND_LANDING{
 			return 0 as u64
-		} else if [*FIGHTER_STATUS_KIND_ATTACK_S4_START, *FIGHTER_STATUS_KIND_ATTACK_HI4_START, *FIGHTER_STATUS_KIND_ATTACK_LW4_START].contains(&next_status){
-			
-			//Kills AB Smash
-			let specials_list = [*CONTROL_PAD_BUTTON_SPECIAL_RAW, *CONTROL_PAD_BUTTON_SPECIAL_RAW2, *CONTROL_PAD_BUTTON_SPECIAL];
-			for i in specials_list {
-					if ControlModule::check_button_on(boma, i) {
-						println!("Ban AB Smash");
-						return 0 as u64
-					}
-			}
-			println!("Keep Smash");
-			original!()(boma, status_kind, arg3)
-		}
+		} 
 		 else if [*FIGHTER_STATUS_KIND_ESCAPE_AIR, *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE, *FIGHTER_STATUS_KIND_JUMP].contains(&next_status)  {
 			let ENTRY_ID = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
 			if IS_WAVEDASH[ENTRY_ID] == true {
@@ -227,7 +215,8 @@ pub unsafe fn change_status_request_hook(boma: &mut smash::app::BattleObjectModu
 			return 0 as u64
 		} else if smash::app::utility::get_kind(boma) == *FIGHTER_KIND_MURABITO && [*FIGHTER_MURABITO_STATUS_KIND_SPECIAL_N_POCKET].contains(&status_kind){
 			original!()(boma, *FIGHTER_STATUS_KIND_ITEM_THROW, arg3)
-		}else if next_status == *FIGHTER_STATUS_KIND_JUMP_SQUAT{
+		}
+		else if next_status == *FIGHTER_STATUS_KIND_JUMP_SQUAT{
 			let ENTRY_ID = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
 			IS_WAVEDASH[ENTRY_ID] = true;
 			if ControlModule::check_button_on_trriger(boma, *CONTROL_PAD_BUTTON_GUARD) {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -502,7 +502,7 @@ pub(crate) unsafe fn is_added(boma: &mut smash::app::BattleObjectModuleAccessor)
 }
 pub(crate) unsafe fn set_knockdown_throw(fighter: &mut L2CAgentBase) -> () {
 	let boma = smash::app::sv_system::battle_object_module_accessor(fighter.lua_state_agent);    
-	let opponent_id = LinkModule::get_parent_object_id(boma, *LINK_NO_CAPTURE) as u32;
+	let opponent_id = LinkModule::get_node_object_id(boma, *LINK_NO_CAPTURE) as u32;
 	let grabber_boma = smash::app::sv_battle_object::module_accessor(opponent_id);
 	let grabber_kind = smash::app::utility::get_kind(&mut *grabber_boma);
 	let grabber_entry_id = WorkModule::get_int(&mut *grabber_boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -500,8 +500,8 @@ pub(crate) unsafe fn is_added(boma: &mut smash::app::BattleObjectModuleAccessor)
 		return false
 	}
 }
-pub(crate) unsafe fn set_knockdown_throw(boma: &mut smash::app::BattleObjectModuleAccessor) -> () {
-	
+pub(crate) unsafe fn set_knockdown_throw(fighter: &mut L2CAgentBase) -> () {
+	let boma = smash::app::sv_system::battle_object_module_accessor(fighter.lua_state_agent);    
 	let opponent_id = LinkModule::get_parent_object_id(boma, *LINK_NO_CAPTURE) as u32;
 	let grabber_boma = smash::app::sv_battle_object::module_accessor(opponent_id);
 	let grabber_kind = smash::app::utility::get_kind(&mut *grabber_boma);

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -21,6 +21,7 @@ pub static mut ACCEL_Y : [f32; 8] = [0.0; 8];
 static mut FULL_HOP_ENABLE_DELAY : [i32; 8] = [0; 8];
 pub static mut PREV_SCALE : [f32; 8] = [0.0; 8];
 pub static mut IS_AB : [bool; 8] = [false; 8];
+pub static mut IS_KD_THROW : [bool; 8] = [false; 8];
 
 
 //Cstick
@@ -498,6 +499,14 @@ pub(crate) unsafe fn is_added(boma: &mut smash::app::BattleObjectModuleAccessor)
 	} else {
 		return false
 	}
+}
+pub(crate) unsafe fn set_knockdown_throw(boma: &mut smash::app::BattleObjectModuleAccessor) -> () {
+	
+	let opponent_id = LinkModule::get_parent_object_id(boma, *LINK_NO_CAPTURE) as u32;
+	let grabber_boma = smash::app::sv_battle_object::module_accessor(opponent_id);
+	let grabber_kind = smash::app::utility::get_kind(&mut *grabber_boma);
+	let grabber_entry_id = WorkModule::get_int(&mut *grabber_boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
+	IS_KD_THROW[grabber_entry_id] = true;
 }
 
 


### PR DESCRIPTION
Adds ability to make throws set up a techchase situation instantly.

How to Use:
1. set the kb values of your throw to Angle 90, KBG 100, FKB 104, BKB 0
2.  add `set_knockdown_throw(fighter);` to the acmd right before the throw release:

Example that produces the clip below:
```
		if macros::is_excute(fighter) {
			macros::ATTACK_ABS(fighter, /*Kind*/ *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, /*ID*/ 0, /*Damage*/ 4.0, /*Angle*/ 90, /*KBG*/ 100, /*FKB*/ 104, /*BKB*/ 0, /*Hitlag*/ 0.0, /*Unk*/ 1.0, /*FacingRestrict*/ *ATTACK_LR_CHECK_B, /*Unk*/ 0.0, /*Unk*/ true, /*Effect*/ Hash40::new("collision_attr_normal"), /*SFXLevel*/ *ATTACK_SOUND_LEVEL_M, /*SFXType*/ *COLLISION_SOUND_ATTR_CUTUP, /*Type*/ *ATTACK_REGION_THROW);
			macros::ATTACK_ABS(fighter, /*Kind*/ *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, /*ID*/ 0, /*Damage*/ 3.0, /*Angle*/ 361, /*KBG*/ 100, /*FKB*/ 0, /*BKB*/ 40, /*Hitlag*/ 0.0, /*Unk*/ 1.0, /*FacingRestrict*/ *ATTACK_LR_CHECK_B, /*Unk*/ 0.0, /*Unk*/ true, /*Effect*/ Hash40::new("collision_attr_normal"), /*SFXLevel*/ *ATTACK_SOUND_LEVEL_S, /*SFXType*/ *COLLISION_SOUND_ATTR_NONE, /*Type*/ *ATTACK_REGION_THROW);
		}
		frame(fighter.lua_state_agent, 9.0);
		if macros::is_excute(fighter) {
			ArticleModule::remove_exist(fighter.module_accessor, *FIGHTER_KOOPAJR_GENERATE_ARTICLE_MAGICHAND,smash::app::ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL));
		}
		frame(fighter.lua_state_agent, 16.0);
		if macros::is_excute(fighter) {
			macros::ATTACK(fighter, /*ID*/ 0, /*Part*/ 0, /*Bone*/ Hash40::new("top"), /*Damage*/ 1.2, /*Angle*/ 361, /*KBG*/ 100, /*FKB*/ 30, /*BKB*/ 0, /*Size*/ 5.0, /*X*/ 0.0, /*Y*/ 4.0, /*Z*/ 0.0, /*X2*/ None, /*Y2*/ None, /*Z2*/ None, /*Hitlag*/ 0.5, /*SDI*/ 1.0, /*Clang_Rebound*/ *ATTACK_SETOFF_KIND_OFF, /*FacingRestrict*/ *ATTACK_LR_CHECK_F, /*SetWeight*/ false, /*ShieldDamage*/ 0, /*Trip*/ 0.0, /*Rehit*/ 5, /*Reflectable*/ false, /*Absorbable*/ false, /*Flinchless*/ false, /*DisableHitlag*/ false, /*Direct_Hitbox*/ true, /*Ground_or_Air*/ *COLLISION_SITUATION_MASK_GA, /*Hitbits*/ *COLLISION_CATEGORY_MASK_ALL, /*CollisionPart*/ *COLLISION_PART_MASK_ALL, /*FriendlyFire*/ false, /*Effect*/ Hash40::new("collision_attr_cutup"), /*SFXLevel*/ *ATTACK_SOUND_LEVEL_M, /*SFXType*/ *COLLISION_SOUND_ATTR_CUTUP, /*Type*/ *ATTACK_REGION_OBJECT);
			AttackModule::set_catch_only_all(fighter.module_accessor, true, false);
		}
		frame(fighter.lua_state_agent, 51.0);
		if macros::is_excute(fighter) {
			set_knockdown_throw(fighter);
			macros::ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), WorkModule::get_int64(fighter.module_accessor,*FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT), WorkModule::get_int64(fighter.module_accessor,*FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP), WorkModule::get_int64(fighter.module_accessor,*FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO));
			AttackModule::clear_all(fighter.module_accessor);
		} 
		
```

https://github.com/chrispo-git/ult-s/assets/69305550/2529f25a-64c7-4ce0-a099-4ef14f31c781

