### PR TITLE
Universal mechanics

### DIFF
--- a/romfs/fighter/common/param/common.prcxml
+++ b/romfs/fighter/common/param/common.prcxml
@@ -9,4 +9,9 @@
   <int hash="hit_stop_delay_flick_frame">1</int>
   <int hash="shield_setoff_catch_frame">1</int>
   <float hash="damage_fly_correction_max">10</float>
+  <int hash="escape_penalty_max_count">1</int>
+  <int hash="escape_penalty_recovry_frame">1</int>
+  <float hash="escape_penalty_motion_rate">0</float>
+  <float hash="escape_f_penalty_motion_rate">0</float>
+  <float hash="escape_b_penalty_motion_rate">0</float>
 </struct>

--- a/src/common/dacus.rs
+++ b/src/common/dacus.rs
@@ -53,8 +53,10 @@ unsafe extern "C" fn dacus(fighter : &mut L2CFighterCommon) {
 				(f6.contains(&fighter_kind) && motion_duration(boma) <= 6) ||
 				(f6.contains(&fighter_kind) == false && motion_duration(boma) <= 8)){
 					if (ControlModule::get_command_flag_cat(boma, 0) & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_HI4) != 0 {
+						JC_GRAB_LOCKOUT[ENTRY_ID] = MAX_LOCKOUT;
 						StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_ATTACK_HI4_START, true);
 					} else if (ControlModule::get_command_flag_cat(boma, 0) & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_LW4) != 0 {
+						JC_GRAB_LOCKOUT[ENTRY_ID] = MAX_LOCKOUT;
 						StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_ATTACK_LW4_START, true);
 					};
 				};

--- a/src/common/dacus.rs
+++ b/src/common/dacus.rs
@@ -13,7 +13,8 @@ use crate::util::*;
 //Dash Attack Cancel Smashes
 unsafe extern "C" fn dacus(fighter : &mut L2CFighterCommon) {
     unsafe {
-        let boma = smash::app::sv_system::battle_object_module_accessor(fighter.lua_state_agent);    
+        let boma = smash::app::sv_system::battle_object_module_accessor(fighter.lua_state_agent); 
+		let ENTRY_ID = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;   
 		let fighter_kind = smash::app::utility::get_kind(boma);
 		let status_kind = smash::app::lua_bind::StatusModule::status_kind(boma);
 		let f6 = [

--- a/src/common/landing.rs
+++ b/src/common/landing.rs
@@ -44,7 +44,11 @@ unsafe extern "C" fn shielddrop(fighter : &mut L2CFighterCommon) {
 		let cancel_frame = FighterMotionModuleImpl::get_cancel_frame(boma,smash::phx::Hash40::new_raw(MotionModule::motion_kind(boma)),false) as f32;
 		let frame = MotionModule::frame(boma);
 		let situation_kind = StatusModule::situation_kind(boma);
-        if [*FIGHTER_STATUS_KIND_GUARD_ON, *FIGHTER_STATUS_KIND_GUARD].contains(&status_kind) &&  sticky <= -0.6875  && GroundModule::is_passable_ground(fighter.module_accessor){
+        if [*FIGHTER_STATUS_KIND_GUARD_ON, *FIGHTER_STATUS_KIND_GUARD].contains(&status_kind) 
+		&&  sticky <= -0.6875  
+		&& GroundModule::is_passable_ground(fighter.module_accessor)
+		&& (ControlModule::get_command_flag_cat(boma, 0) & *FIGHTER_PAD_CMD_CAT1_FLAG_ESCAPE) == 0
+		{
 			StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_PASS, true);
 		};
     };

--- a/src/common/landing.rs
+++ b/src/common/landing.rs
@@ -45,9 +45,9 @@ unsafe extern "C" fn shielddrop(fighter : &mut L2CFighterCommon) {
 		let frame = MotionModule::frame(boma);
 		let situation_kind = StatusModule::situation_kind(boma);
         if [*FIGHTER_STATUS_KIND_GUARD_ON, *FIGHTER_STATUS_KIND_GUARD].contains(&status_kind) 
-		&&  sticky <= -0.6875  
+		&&  sticky <= WorkModule::get_param_float(boma, hash40("common"), hash40("squat_stick_y"))  
 		&& GroundModule::is_passable_ground(fighter.module_accessor)
-		&& (ControlModule::get_command_flag_cat(boma, 0) & *FIGHTER_PAD_CMD_CAT1_FLAG_ESCAPE) == 0
+		&& (ControlModule::get_command_flag_cat(boma, 1) & *FIGHTER_PAD_CMD_CAT2_FLAG_STICK_ESCAPE) == 0
 		{
 			StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_PASS, true);
 		};

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -39,6 +39,11 @@ pub static mut DJ_DELAY : [i32; 8] = [0; 8];
 pub static mut DELAY_FRAMES: i32 = 30;
 pub static mut DJ_DELAY_FRAMES: i32 = 21;
 
+pub const MAX_WEIGHT : i32 = 150;
+pub const MIN_WEIGHT : i32 = 60;
+pub const MAX_GRAVITY : f32 = 0.1;
+pub const MIN_GRAVITY : f32 = 0.065;
+
 
 static mut IS_CALCULATING: Option<(u32, u32)> = None;
 
@@ -75,6 +80,7 @@ pub unsafe extern "C" fn process_toonlinkbomb_knockback(defender: u32, attacker:
         }
     }
 }
+
 pub fn install() {
     hitstun::install();
     dacus::install();
@@ -93,4 +99,9 @@ pub fn install() {
         process_knockback,
         calculate_knockback
     );*/
+
+    //Setting values for everybody!
+    let all: Vec<i32> = vec![-1];
+    param_config::update_attribute_mul_2(*FIGHTER_KIND_ALL, all.clone(), (smash::hash40("damage_fly_top_air_accel_y"), 0, 1.05));
+    param_config::update_float_2(*FIGHTER_KIND_ALL, all.clone(), (smash::hash40("damage_fly_top_speed_y_stable"), 0, 1.84));
 }

--- a/src/common/movement.rs
+++ b/src/common/movement.rs
@@ -98,9 +98,10 @@ unsafe extern "C" fn djc(fighter : &mut L2CFighterCommon) {
 		let ENTRY_ID = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
 		let fighter_kind = smash::app::utility::get_kind(boma);
 		let status_kind = smash::app::lua_bind::StatusModule::status_kind(boma);
+        let is_tap_jump = ControlModule::get_stick_y(boma) >= 0.6875 && ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_FLICK_JUMP);
 		if [*FIGHTER_KIND_NESS, *FIGHTER_KIND_LUCAS, /**FIGHTER_KIND_YOSHI,*/ *FIGHTER_KIND_MEWTWO].contains(&fighter_kind) {
 			if [*FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION_2ND, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL].contains(&KineticModule::get_kinetic_type(boma)) {
-				if ControlModule::check_button_off(boma, *CONTROL_PAD_BUTTON_JUMP) && [*FIGHTER_TRAIL_STATUS_KIND_ATTACK_AIR_N, *FIGHTER_STATUS_KIND_ATTACK_AIR, *FIGHTER_STATUS_KIND_AIR_LASSO].contains(&status_kind) {
+				if !is_tap_jump && ControlModule::check_button_off(boma, *CONTROL_PAD_BUTTON_JUMP) && [*FIGHTER_TRAIL_STATUS_KIND_ATTACK_AIR_N, *FIGHTER_STATUS_KIND_ATTACK_AIR, *FIGHTER_STATUS_KIND_AIR_LASSO].contains(&status_kind) {
 					KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_MOTION_FALL);
 				};
 				if KineticModule::get_kinetic_type(boma) == *FIGHTER_KINETIC_TYPE_JUMP_AERIAL {
@@ -110,7 +111,7 @@ unsafe extern "C" fn djc(fighter : &mut L2CFighterCommon) {
 		};
 		if [*FIGHTER_KIND_TRAIL].contains(&fighter_kind) && Path::new("sd:/ultimate/ult-s/trail.flag").is_file() {
 			if [*FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION_2ND, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL].contains(&KineticModule::get_kinetic_type(boma)) {
-				if ControlModule::check_button_off(boma, *CONTROL_PAD_BUTTON_JUMP) && [*FIGHTER_TRAIL_STATUS_KIND_ATTACK_AIR_N, *FIGHTER_STATUS_KIND_ATTACK_AIR, *FIGHTER_STATUS_KIND_AIR_LASSO].contains(&status_kind) {
+				if !is_tap_jump && ControlModule::check_button_off(boma, *CONTROL_PAD_BUTTON_JUMP) && [*FIGHTER_TRAIL_STATUS_KIND_ATTACK_AIR_N, *FIGHTER_STATUS_KIND_ATTACK_AIR, *FIGHTER_STATUS_KIND_AIR_LASSO].contains(&status_kind) {
 					KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_MOTION_FALL);
 					if SPEED_Y[ENTRY_ID] > 2.5 {
 						let new_speed = SPEED_X[ENTRY_ID]*PostureModule::lr(fighter.module_accessor);

--- a/src/common/movement.rs
+++ b/src/common/movement.rs
@@ -78,6 +78,19 @@ unsafe extern "C" fn moonwalk(fighter : &mut L2CFighterCommon) {
 		};
     };
 }
+//JC Grab
+unsafe extern "C" fn jc_grab(fighter : &mut L2CFighterCommon) {
+    unsafe {
+        let boma = smash::app::sv_system::battle_object_module_accessor(fighter.lua_state_agent);  
+        if [*FIGHTER_STATUS_KIND_JUMP_SQUAT].contains(&status_kind){
+            if JC_GRAB_LOCKOUT[ENTRY_ID] == 0 && ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_CATCH) {
+                JC_GRAB_LOCKOUT[ENTRY_ID] = MAX_LOCKOUT;
+                StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_CATCH, true);
+            };
+		};
+    };
+}
+
 //DJC
 unsafe extern "C" fn djc(fighter : &mut L2CFighterCommon) {
     unsafe {
@@ -328,6 +341,7 @@ pub fn install() {
 	.on_line(Main, djc)
 	.on_line(Main, hold_buffer_killer)
     .on_line(Main, moonwalk)
+    .on_line(Main, jc_grab)
 	.install();
     skyline::nro::add_hook(nro_hook);
 }

--- a/src/common/movement.rs
+++ b/src/common/movement.rs
@@ -87,6 +87,9 @@ unsafe extern "C" fn jc_grab(fighter : &mut L2CFighterCommon) {
         if [*FIGHTER_STATUS_KIND_JUMP_SQUAT].contains(&status_kind){
             if JC_GRAB_LOCKOUT[ENTRY_ID] == 0 && ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_CATCH) {
                 JC_GRAB_LOCKOUT[ENTRY_ID] = MAX_LOCKOUT;
+                GroundModule::attach_ground(fighter.module_accessor, true);
+                GroundModule::set_attach_ground(fighter.module_accessor, true);
+                StatusModule::set_situation_kind(boma, smash::app::SituationKind(*SITUATION_KIND_GROUND), true);
                 StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_CATCH, true);
             };
 		};

--- a/src/common/movement.rs
+++ b/src/common/movement.rs
@@ -84,7 +84,7 @@ unsafe extern "C" fn jc_grab(fighter : &mut L2CFighterCommon) {
         let boma = smash::app::sv_system::battle_object_module_accessor(fighter.lua_state_agent);  
 		let ENTRY_ID = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
 		let status_kind = smash::app::lua_bind::StatusModule::status_kind(boma);
-        if [*FIGHTER_STATUS_KIND_JUMP_SQUAT].contains(&status_kind){
+        if [*FIGHTER_STATUS_KIND_JUMP_SQUAT].contains(&status_kind) && StatusModule::situation_kind(boma) == *SITUATION_KIND_GROUND{
             if JC_GRAB_LOCKOUT[ENTRY_ID] == 0 && ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_CATCH) {
                 JC_GRAB_LOCKOUT[ENTRY_ID] = MAX_LOCKOUT;
                 GroundModule::attach_ground(fighter.module_accessor, true);

--- a/src/common/movement.rs
+++ b/src/common/movement.rs
@@ -104,7 +104,7 @@ unsafe extern "C" fn djc(fighter : &mut L2CFighterCommon) {
 		if [*FIGHTER_KIND_NESS, *FIGHTER_KIND_LUCAS, /**FIGHTER_KIND_YOSHI,*/ *FIGHTER_KIND_MEWTWO].contains(&fighter_kind) {
 			if [*FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION_2ND, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL].contains(&KineticModule::get_kinetic_type(boma)) {
                 if ControlModule::check_button_off(boma, *CONTROL_PAD_BUTTON_JUMP) && [*FIGHTER_TRAIL_STATUS_KIND_ATTACK_AIR_N, *FIGHTER_STATUS_KIND_ATTACK_AIR, *FIGHTER_STATUS_KIND_AIR_LASSO].contains(&status_kind) {
-					if !(ControlModule::get_stick_y(boma) >= 0.6875 && ControlModule::is_enable_flick_jump(boma)) {
+					if is_tap_djc(boma) {
                         KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_MOTION_FALL);
                     }
 				};
@@ -114,10 +114,9 @@ unsafe extern "C" fn djc(fighter : &mut L2CFighterCommon) {
 			};
 		};
 		if [*FIGHTER_KIND_TRAIL].contains(&fighter_kind) && Path::new("sd:/ultimate/ult-s/trail.flag").is_file() {
-            println!("Is Tap Jump? {}", ControlModule::is_enable_flick_jump(boma));
 			if [*FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION_2ND, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL].contains(&KineticModule::get_kinetic_type(boma)) {
 				if ControlModule::check_button_off(boma, *CONTROL_PAD_BUTTON_JUMP) && [*FIGHTER_TRAIL_STATUS_KIND_ATTACK_AIR_N, *FIGHTER_STATUS_KIND_ATTACK_AIR, *FIGHTER_STATUS_KIND_AIR_LASSO].contains(&status_kind) {
-					if !(ControlModule::get_stick_y(boma) >= 0.6875 && ControlModule::is_enable_flick_jump(boma)) {
+					if is_tap_djc(boma) {
                         KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_MOTION_FALL);
                         if SPEED_Y[ENTRY_ID] > 2.5 {
                             let new_speed = SPEED_X[ENTRY_ID]*PostureModule::lr(fighter.module_accessor);

--- a/src/trail/status.rs
+++ b/src/trail/status.rs
@@ -36,7 +36,7 @@ unsafe extern "C" fn fair_init(fighter: &mut L2CFighterCommon) -> L2CValue {
         }
         if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_IGNORE_2ND_MOTION){
         }
-        if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) {
+        if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) || (!is_tap_djc(&mut *fighter.module_accessor)) {
             KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION_2ND);
         } else {
             KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_MOTION_FALL);
@@ -60,12 +60,12 @@ unsafe extern "C" fn init_attack_air(fighter: &mut L2CFighterCommon) -> L2CValue
     if motion_kind != hash40("jump_aerial_f") {
         if motion_kind == hash40("jump_aerial_b"){
                 if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_IGNORE_2ND_MOTION) {
-                    if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) {
+                    if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) || (!is_tap_djc(&mut *fighter.module_accessor)) {
                         MotionModule::add_motion_2nd(fighter.module_accessor, Hash40::new_raw(motion_kind), frame, 1.0, false, 1.0);
                         MotionModule::set_weight(fighter.module_accessor, 1.0, true);
                     }
                 }
-                if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) {
+                if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) || (!is_tap_djc(&mut *fighter.module_accessor)) {
                     KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION_2ND);
                 }
                 else {
@@ -81,12 +81,12 @@ unsafe extern "C" fn init_attack_air(fighter: &mut L2CFighterCommon) -> L2CValue
     }
     else {
             if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_IGNORE_2ND_MOTION) {
-                if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) {
+                if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) || (!is_tap_djc(&mut *fighter.module_accessor)) {
                     MotionModule::add_motion_2nd(fighter.module_accessor, Hash40::new_raw(motion_kind), frame, 1.0, false, 1.0);
                     MotionModule::set_weight(fighter.module_accessor, 1.0, true);
                 }
             }
-            if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) {
+            if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) || (!is_tap_djc(&mut *fighter.module_accessor)) {
                 KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION_2ND);
             }
             else {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -30,6 +30,10 @@ pub static mut IS_AB : [bool; 8] = [false; 8];
 pub static mut IS_KD_THROW : [bool; 8] = [false; 8];
 
 
+pub static mut JC_GRAB_LOCKOUT : [i32; 8] = [0; 8];
+pub const MAX_LOCKOUT : i32 = 10;
+
+
 //Cstick
 pub static mut SUB_STICK: [Vector2f;9] = [Vector2f{x:0.0, y: 0.0};9];
 
@@ -271,6 +275,7 @@ unsafe extern "C" fn util_update(fighter : &mut L2CFighterCommon) {
 		};
 		//Resets inability to special
 		if is_reset() {
+			JC_GRAB_LOCKOUT[ENTRY_ID] = 0;
 			CAN_ATTACK_AIR[ENTRY_ID] = 0;
 			CAN_JUMP_SQUAT[ENTRY_ID] = 0;
 			CAN_DOUBLE_JUMP[ENTRY_ID] = 0;
@@ -289,6 +294,9 @@ unsafe extern "C" fn util_update(fighter : &mut L2CFighterCommon) {
 		};
 		if FULL_HOP_ENABLE_DELAY[ENTRY_ID] > 0 {
 			FULL_HOP_ENABLE_DELAY[ENTRY_ID] -= 1;
+		};
+		if JC_GRAB_LOCKOUT[ENTRY_ID] > 0 {
+			JC_GRAB_LOCKOUT[ENTRY_ID] -= 1;
 		};
 		if  PostureModule::scale(boma) != 0.001345 {
 			PREV_SCALE[ENTRY_ID] = PostureModule::scale(boma);

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -28,6 +28,7 @@ static mut FULL_HOP_ENABLE_DELAY : [i32; 8] = [0; 8];
 pub static mut PREV_SCALE : [f32; 8] = [0.0; 8];
 pub static mut IS_AB : [bool; 8] = [false; 8];
 pub static mut IS_KD_THROW : [bool; 8] = [false; 8];
+pub static mut IS_TAP_JUMP : [i32; 8] = [0; 8];
 
 
 pub static mut JC_GRAB_LOCKOUT : [i32; 8] = [0; 8];
@@ -586,6 +587,22 @@ pub(crate) unsafe fn set_knockdown_throw(fighter: &mut L2CAgentBase) -> () {
 	let grabber_kind = smash::app::utility::get_kind(&mut *grabber_boma);
 	let grabber_entry_id = WorkModule::get_int(&mut *grabber_boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
 	IS_KD_THROW[grabber_entry_id] = true;
+}
+
+pub(crate) unsafe fn is_tap_jump(boma: &mut smash::app::BattleObjectModuleAccessor) -> bool {
+	let ENTRY_ID = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
+	if IS_TAP_JUMP[ENTRY_ID] == 0 {
+		println!("update!");
+		IS_TAP_JUMP[ENTRY_ID] = match ControlModule::is_enable_flick_jump(boma) {
+			true => 1,
+			false => -1,
+			_ => 0,
+		};
+	}
+	return match IS_TAP_JUMP[ENTRY_ID] {
+		1 => true,
+		_ => false,
+	};
 }
 
 


### PR DESCRIPTION
You can now JC Grab:
- unable to do this out of dacus

DJC now works correctly with tap jump:
- 6 frame forgiveness window for rising dj aerial
- Solves #568

Shield Plat Drop less forgiving:
- ensures spotdodging out of shield on a platform is more consistent


Dropping from platforms during attack endlag made more forgiving

Respawning animation adjusted

Dodge Staling Removed

Vertical knockback adjusted:
- Vertical kb gravity is now 5% higher
- Vertical kb fallspeed increased 1.8 -> 1.85